### PR TITLE
fix: add types to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "files": [
     "index.js",
     "postinstall.js",
-    "bin/ngrok"
+    "bin/ngrok",
+    "ngrok.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
`ngrok.d.ts` wasn't referenced in the `files` array in `package.json`, so the types weren't being installed alongside the package (see screenshot with lack of ngrok.d.ts in file explorer with latest version).
![image](https://user-images.githubusercontent.com/15040698/30006872-937aeb70-90d0-11e7-920d-6e35eab38705.png)
